### PR TITLE
fix: Error related with save or update information into json files

### DIFF
--- a/src/DistributionCenter.Application/Tables/Connections/File/Concretes/JsonConnectionFactory.cs
+++ b/src/DistributionCenter.Application/Tables/Connections/File/Concretes/JsonConnectionFactory.cs
@@ -6,8 +6,6 @@ using File = System.IO.File;
 
 public class JsonConnectionFactory<T> (string tableName) : FileConnectionFactory<T>(tableName, "json")
 {
-    private readonly string _tableName = tableName;
-
     public override async Task<List<T>> LoadDataAsync()
     {
         string jsonData = await OpenFileAsync();
@@ -16,7 +14,10 @@ public class JsonConnectionFactory<T> (string tableName) : FileConnectionFactory
 
     public override async Task SaveDataAsync(IEnumerable<T> data)
     {
-        string jsonData = JsonConvert.SerializeObject(data, Formatting.Indented);
-        await File.WriteAllTextAsync(_tableName, jsonData);
+        List<T> existingData = await LoadDataAsync();
+        existingData.AddRange(data);
+
+        string jsonData = JsonConvert.SerializeObject(existingData, Formatting.Indented);
+        await File.WriteAllTextAsync(CompletedFilePath, jsonData);
     }
 }

--- a/test/DistributionCenter.Application.Tests/Resources/TransportsTest.json
+++ b/test/DistributionCenter.Application.Tests/Resources/TransportsTest.json
@@ -5,7 +5,7 @@
     "AvailableUnits": 10,
     "Id": "b1a4e1f1-d0c7-49b0-9c45-3e6c9c34d375",
     "IsActive": true,
-    "CreatedAt": "2024-09-13T00:58:56.6771739-04:00",
+    "CreatedAt": "2024-09-13T01:13:23.1524897-04:00",
     "UpdatedAt": null
   },
   {
@@ -14,7 +14,7 @@
     "AvailableUnits": 5,
     "Id": "ac456efb-e89b-4a3c-93f4-8bcdd49bfe56",
     "IsActive": true,
-    "CreatedAt": "2024-09-13T00:58:56.6772525-04:00",
+    "CreatedAt": "2024-09-13T01:13:23.1525478-04:00",
     "UpdatedAt": null
   },
   {
@@ -23,7 +23,7 @@
     "AvailableUnits": 8,
     "Id": "f8b3b85d-1b51-4d71-bafe-96cb4c61c9f7",
     "IsActive": true,
-    "CreatedAt": "2024-09-13T00:58:56.6772889-04:00",
+    "CreatedAt": "2024-09-13T01:13:23.1525716-04:00",
     "UpdatedAt": null
   },
   {
@@ -32,26 +32,26 @@
     "AvailableUnits": 12,
     "Id": "3c4913a5-017b-4b7b-85a5-ea5a0e54e1c2",
     "IsActive": true,
-    "CreatedAt": "2024-09-13T00:58:56.6773249-04:00",
+    "CreatedAt": "2024-09-13T01:13:23.1526001-04:00",
     "UpdatedAt": null
   },
   {
     "Name": "Truck AB",
     "Capacity": 2000,
     "AvailableUnits": 10,
-    "Id": "646509b7-8286-4dd9-9b23-4a88fba98655",
+    "Id": "cf1155a5-04e0-4ba3-9edc-40dd19b2fd92",
     "IsActive": true,
-    "CreatedAt": "2024-09-13T04:58:56.6735399Z",
-    "UpdatedAt": "2024-09-13T04:58:56.6737072Z"
+    "CreatedAt": "2024-09-13T05:13:23.1485837Z",
+    "UpdatedAt": "2024-09-13T05:13:23.1486754Z"
   },
   {
     "Name": "Van BC",
     "Capacity": 1000,
     "AvailableUnits": 5,
-    "Id": "dd4a63df-ec24-4a89-af4d-fc880bdf6285",
+    "Id": "6ee51382-135c-4df0-bc11-07932f1cc17d",
     "IsActive": true,
-    "CreatedAt": "2024-09-13T04:58:56.6738318Z",
-    "UpdatedAt": "2024-09-13T04:58:56.6738319Z"
+    "CreatedAt": "2024-09-13T05:13:23.1487656Z",
+    "UpdatedAt": "2024-09-13T05:13:23.1487657Z"
   },
   {
     "Name": "Truck A",
@@ -59,7 +59,7 @@
     "AvailableUnits": 10,
     "Id": "b1a4e1f1-d0c7-49b0-9c45-3e6c9c34d375",
     "IsActive": true,
-    "CreatedAt": "2024-09-13T00:58:56.6771739-04:00",
+    "CreatedAt": "2024-09-13T01:13:23.1524897-04:00",
     "UpdatedAt": null
   },
   {
@@ -68,7 +68,7 @@
     "AvailableUnits": 5,
     "Id": "ac456efb-e89b-4a3c-93f4-8bcdd49bfe56",
     "IsActive": true,
-    "CreatedAt": "2024-09-13T00:58:56.6772525-04:00",
+    "CreatedAt": "2024-09-13T01:13:23.1525478-04:00",
     "UpdatedAt": null
   },
   {
@@ -77,7 +77,7 @@
     "AvailableUnits": 8,
     "Id": "f8b3b85d-1b51-4d71-bafe-96cb4c61c9f7",
     "IsActive": true,
-    "CreatedAt": "2024-09-13T00:58:56.6772889-04:00",
+    "CreatedAt": "2024-09-13T01:13:23.1525716-04:00",
     "UpdatedAt": null
   },
   {
@@ -86,7 +86,7 @@
     "AvailableUnits": 12,
     "Id": "3c4913a5-017b-4b7b-85a5-ea5a0e54e1c2",
     "IsActive": true,
-    "CreatedAt": "2024-09-13T00:58:56.6773249-04:00",
+    "CreatedAt": "2024-09-13T01:13:23.1526001-04:00",
     "UpdatedAt": null
   }
 ]

--- a/test/DistributionCenter.Application.Tests/Resources/TransportsTest.json
+++ b/test/DistributionCenter.Application.Tests/Resources/TransportsTest.json
@@ -1,38 +1,92 @@
 [
-    {
-        "id": "b1a4e1f1-d0c7-49b0-9c45-3e6c9c34d375",
-        "name": "Truck A",
-        "capacity": 2000,
-        "availableUnits": 10,
-        "is_active": true,
-        "created_at": "2024-09-12T12:00:00Z",
-        "updated_at": "2024-09-12T12:00:00Z"
-    },
-    {
-        "id": "ac456efb-e89b-4a3c-93f4-8bcdd49bfe56",
-        "name": "Van B",
-        "capacity": 1000,
-        "availableUnits": 5,
-        "is_active": true,
-        "created_at": "2024-09-12T12:00:00Z",
-        "updated_at": "2024-09-12T12:00:00Z"
-    },
-    {
-        "id": "f8b3b85d-1b51-4d71-bafe-96cb4c61c9f7",
-        "name": "Truck C",
-        "capacity": 3000,
-        "availableUnits": 8,
-        "is_active": true,
-        "created_at": "2024-09-12T12:00:00Z",
-        "updated_at": "2024-09-12T12:00:00Z"
-    },
-    {
-        "id": "3c4913a5-017b-4b7b-85a5-ea5a0e54e1c2",
-        "name": "Truck D",
-        "capacity": 1500,
-        "availableUnits": 12,
-        "is_active": false,
-        "created_at": "2024-09-12T12:00:00Z",
-        "updated_at": "2024-09-12T12:00:00Z"
-    }
+  {
+    "Name": "Truck A",
+    "Capacity": 2000,
+    "AvailableUnits": 10,
+    "Id": "b1a4e1f1-d0c7-49b0-9c45-3e6c9c34d375",
+    "IsActive": true,
+    "CreatedAt": "2024-09-13T00:58:56.6771739-04:00",
+    "UpdatedAt": null
+  },
+  {
+    "Name": "Van B",
+    "Capacity": 1000,
+    "AvailableUnits": 5,
+    "Id": "ac456efb-e89b-4a3c-93f4-8bcdd49bfe56",
+    "IsActive": true,
+    "CreatedAt": "2024-09-13T00:58:56.6772525-04:00",
+    "UpdatedAt": null
+  },
+  {
+    "Name": "Truck C",
+    "Capacity": 3000,
+    "AvailableUnits": 8,
+    "Id": "f8b3b85d-1b51-4d71-bafe-96cb4c61c9f7",
+    "IsActive": true,
+    "CreatedAt": "2024-09-13T00:58:56.6772889-04:00",
+    "UpdatedAt": null
+  },
+  {
+    "Name": "Truck D",
+    "Capacity": 1500,
+    "AvailableUnits": 12,
+    "Id": "3c4913a5-017b-4b7b-85a5-ea5a0e54e1c2",
+    "IsActive": true,
+    "CreatedAt": "2024-09-13T00:58:56.6773249-04:00",
+    "UpdatedAt": null
+  },
+  {
+    "Name": "Truck AB",
+    "Capacity": 2000,
+    "AvailableUnits": 10,
+    "Id": "646509b7-8286-4dd9-9b23-4a88fba98655",
+    "IsActive": true,
+    "CreatedAt": "2024-09-13T04:58:56.6735399Z",
+    "UpdatedAt": "2024-09-13T04:58:56.6737072Z"
+  },
+  {
+    "Name": "Van BC",
+    "Capacity": 1000,
+    "AvailableUnits": 5,
+    "Id": "dd4a63df-ec24-4a89-af4d-fc880bdf6285",
+    "IsActive": true,
+    "CreatedAt": "2024-09-13T04:58:56.6738318Z",
+    "UpdatedAt": "2024-09-13T04:58:56.6738319Z"
+  },
+  {
+    "Name": "Truck A",
+    "Capacity": 2000,
+    "AvailableUnits": 10,
+    "Id": "b1a4e1f1-d0c7-49b0-9c45-3e6c9c34d375",
+    "IsActive": true,
+    "CreatedAt": "2024-09-13T00:58:56.6771739-04:00",
+    "UpdatedAt": null
+  },
+  {
+    "Name": "Van B",
+    "Capacity": 1000,
+    "AvailableUnits": 5,
+    "Id": "ac456efb-e89b-4a3c-93f4-8bcdd49bfe56",
+    "IsActive": true,
+    "CreatedAt": "2024-09-13T00:58:56.6772525-04:00",
+    "UpdatedAt": null
+  },
+  {
+    "Name": "Truck C",
+    "Capacity": 3000,
+    "AvailableUnits": 8,
+    "Id": "f8b3b85d-1b51-4d71-bafe-96cb4c61c9f7",
+    "IsActive": true,
+    "CreatedAt": "2024-09-13T00:58:56.6772889-04:00",
+    "UpdatedAt": null
+  },
+  {
+    "Name": "Truck D",
+    "Capacity": 1500,
+    "AvailableUnits": 12,
+    "Id": "3c4913a5-017b-4b7b-85a5-ea5a0e54e1c2",
+    "IsActive": true,
+    "CreatedAt": "2024-09-13T00:58:56.6773249-04:00",
+    "UpdatedAt": null
+  }
 ]

--- a/test/DistributionCenter.Application.Tests/Resources/TransportsTest.json
+++ b/test/DistributionCenter.Application.Tests/Resources/TransportsTest.json
@@ -5,7 +5,7 @@
     "AvailableUnits": 10,
     "Id": "b1a4e1f1-d0c7-49b0-9c45-3e6c9c34d375",
     "IsActive": true,
-    "CreatedAt": "2024-09-13T01:13:23.1524897-04:00",
+    "CreatedAt": "2024-09-13T01:20:31.3950909-04:00",
     "UpdatedAt": null
   },
   {
@@ -14,7 +14,7 @@
     "AvailableUnits": 5,
     "Id": "ac456efb-e89b-4a3c-93f4-8bcdd49bfe56",
     "IsActive": true,
-    "CreatedAt": "2024-09-13T01:13:23.1525478-04:00",
+    "CreatedAt": "2024-09-13T01:20:31.3951266-04:00",
     "UpdatedAt": null
   },
   {
@@ -23,7 +23,7 @@
     "AvailableUnits": 8,
     "Id": "f8b3b85d-1b51-4d71-bafe-96cb4c61c9f7",
     "IsActive": true,
-    "CreatedAt": "2024-09-13T01:13:23.1525716-04:00",
+    "CreatedAt": "2024-09-13T01:20:31.3951404-04:00",
     "UpdatedAt": null
   },
   {
@@ -32,61 +32,25 @@
     "AvailableUnits": 12,
     "Id": "3c4913a5-017b-4b7b-85a5-ea5a0e54e1c2",
     "IsActive": true,
-    "CreatedAt": "2024-09-13T01:13:23.1526001-04:00",
+    "CreatedAt": "2024-09-13T01:20:31.3951549-04:00",
     "UpdatedAt": null
   },
   {
     "Name": "Truck AB",
     "Capacity": 2000,
     "AvailableUnits": 10,
-    "Id": "cf1155a5-04e0-4ba3-9edc-40dd19b2fd92",
+    "Id": "4e15c6f6-e870-4506-9eb8-50cf45f3f405",
     "IsActive": true,
-    "CreatedAt": "2024-09-13T05:13:23.1485837Z",
-    "UpdatedAt": "2024-09-13T05:13:23.1486754Z"
+    "CreatedAt": "2024-09-13T05:20:31.3935727Z",
+    "UpdatedAt": "2024-09-13T05:20:31.393648Z"
   },
   {
     "Name": "Van BC",
     "Capacity": 1000,
     "AvailableUnits": 5,
-    "Id": "6ee51382-135c-4df0-bc11-07932f1cc17d",
+    "Id": "a0ecd161-fd5c-45e9-a043-34fa8a6e5305",
     "IsActive": true,
-    "CreatedAt": "2024-09-13T05:13:23.1487656Z",
-    "UpdatedAt": "2024-09-13T05:13:23.1487657Z"
-  },
-  {
-    "Name": "Truck A",
-    "Capacity": 2000,
-    "AvailableUnits": 10,
-    "Id": "b1a4e1f1-d0c7-49b0-9c45-3e6c9c34d375",
-    "IsActive": true,
-    "CreatedAt": "2024-09-13T01:13:23.1524897-04:00",
-    "UpdatedAt": null
-  },
-  {
-    "Name": "Van B",
-    "Capacity": 1000,
-    "AvailableUnits": 5,
-    "Id": "ac456efb-e89b-4a3c-93f4-8bcdd49bfe56",
-    "IsActive": true,
-    "CreatedAt": "2024-09-13T01:13:23.1525478-04:00",
-    "UpdatedAt": null
-  },
-  {
-    "Name": "Truck C",
-    "Capacity": 3000,
-    "AvailableUnits": 8,
-    "Id": "f8b3b85d-1b51-4d71-bafe-96cb4c61c9f7",
-    "IsActive": true,
-    "CreatedAt": "2024-09-13T01:13:23.1525716-04:00",
-    "UpdatedAt": null
-  },
-  {
-    "Name": "Truck D",
-    "Capacity": 1500,
-    "AvailableUnits": 12,
-    "Id": "3c4913a5-017b-4b7b-85a5-ea5a0e54e1c2",
-    "IsActive": true,
-    "CreatedAt": "2024-09-13T01:13:23.1526001-04:00",
-    "UpdatedAt": null
+    "CreatedAt": "2024-09-13T05:20:31.393722Z",
+    "UpdatedAt": "2024-09-13T05:20:31.393722Z"
   }
 ]

--- a/test/DistributionCenter.Application.Tests/Tables/Connections/File/Concretes/JsonConnectionFactoryTests.cs
+++ b/test/DistributionCenter.Application.Tests/Tables/Connections/File/Concretes/JsonConnectionFactoryTests.cs
@@ -83,8 +83,6 @@ public class JsonConnectionFactoryTests
         await FIllFileAsync();
 
         // Define Input and Output
-        int initialCount = 4;
-
         List<Transport> transports =
         [
             new()
@@ -117,9 +115,5 @@ public class JsonConnectionFactoryTests
         Assert.Equal(6, savedTransports.Count);
         Assert.Equal("Truck A", savedTransports[0].Name);
         Assert.Equal("Van BC", savedTransports[5].Name);
-
-        List<Transport> transportsToKeep = savedTransports.Take(initialCount).ToList();
-        await _jsonConnectionFactory.SaveDataAsync(transportsToKeep);
-
     }
 }


### PR DESCRIPTION
# Pull Request

This pull request fixes a bug that caused the creation of duplicate instances of objects when saving or updating data in JSON files. The bug occurred when performing create or update operations, which caused objects to be written twice to the persistence file, resulting in duplicates of the same instances. The fix ensures that only a single instance per object is saved when performing persistence operations.

<!--
  Thanks for contributing to this API project!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality
      to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
