### PR TITLE
feat: calculate estimated arrival time into the route for each point

### DIFF
--- a/src/DistributionCenter.Services/Routes/Dtos/WayPointDto.cs
+++ b/src/DistributionCenter.Services/Routes/Dtos/WayPointDto.cs
@@ -6,4 +6,7 @@ public class WayPointDto (GeoPoint point, int priority)
 {
     public GeoPoint Point { get; set; } = point;
     public int Priority { get; set; } = priority;
+
+    public DateTime DeliverTime { get; set; } = DateTime.UtcNow;
+
 }

--- a/src/DistributionCenter.Services/Routes/Interfaces/IRouteService.cs
+++ b/src/DistributionCenter.Services/Routes/Interfaces/IRouteService.cs
@@ -6,5 +6,5 @@ using Localization.Commons;
 
 public interface IRouteService
 {
-    Task<Result<IReadOnlyList<WayPointDto>>> GetOptimalRoute(GeoPoint startPoint, IReadOnlyList<GeoPoint> geoPoints);
+    Task<Result<IReadOnlyList<WayPointDto>>> GetOptimalRoute(GeoPoint startPoint, IReadOnlyList<GeoPoint> geoPoints, DateTime startTime);
 }


### PR DESCRIPTION
# Pull Request

<!--
  Thanks for contributing to this API project!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

I added the time estimate when a route is generated and you can see the estimated arrival time for each delivery point, only the service is implemented

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality
      to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
