### PR TITLE
fix: bug creating and editing a product requires one more field weight

### DIFF
--- a/src/DistributionCenter.Infraestructure/DTOs/Concretes/Products/UpdateProductDto.cs
+++ b/src/DistributionCenter.Infraestructure/DTOs/Concretes/Products/UpdateProductDto.cs
@@ -7,8 +7,9 @@ using Validators.Core.Concretes.Products;
 
 public class UpdateProductDto : IUpdateDto<Product>
 {
-    public string? Name { get; init; }
-    public string? Description { get; init; }
+    public required string? Name { get; init; }
+    public required string? Description { get; init; }
+    public required int? Weight { get; init; }
 
     public Product FromEntity(Product entity)
     {
@@ -16,6 +17,7 @@ public class UpdateProductDto : IUpdateDto<Product>
 
         entity.Name = Name ?? entity.Name;
         entity.Description = Description ?? entity.Description;
+        entity.Weight = Weight ?? entity.Weight;
 
         return entity;
     }

--- a/src/DistributionCenter.Infraestructure/Validators/Core/Concretes/Clients/UpdateClientValidator.cs
+++ b/src/DistributionCenter.Infraestructure/Validators/Core/Concretes/Clients/UpdateClientValidator.cs
@@ -18,6 +18,8 @@ public class UpdateClientValidator : BaseFluentValidator<UpdateClientDto>
             .SizeRange(3, 50, "LastName must be between 3 and 50 characters")
             .RegexValidator(@"^[a-zA-Z\s]+$", "LastName must contain only letters and spaces");
 
-        _ = RuleFor(static x => x.Email).WhenNotNull().EmailValidator("Email is not valid email");
+        _ = RuleFor(static x => x.Email)
+            .WhenNotNull()
+            .EmailValidator("Email is not valid email");
     }
 }

--- a/src/DistributionCenter.Infraestructure/Validators/Core/Concretes/Products/CreateProductValidator.cs
+++ b/src/DistributionCenter.Infraestructure/Validators/Core/Concretes/Products/CreateProductValidator.cs
@@ -9,14 +9,14 @@ public class CreateProductValidator : BaseFluentValidator<CreateProductDto>
     public CreateProductValidator()
     {
         _ = RuleFor(static product => product.Name)!
-            .WhenNotNull()
+            .NotNullNotEmpty("Name is required")
             .SizeRange(3, 64, "Name must be between 3 and 64 characters")
             .RegexValidator(
                 @"^[a-zA-Z0-9\s\.]+$",
                 "Name must contain letters, decimal and the follow characters: .,-_");
 
         _ = RuleFor(static product => product.Description)!
-            .WhenNotNull()
+            .NotNullNotEmpty("Description is required")
             .SizeRange(3, 128, "The description has a limit of 128 characters");
 
         _ = RuleFor(static product => product.Weight)

--- a/src/DistributionCenter.Infraestructure/Validators/Core/Concretes/Products/UpdateProductValidator.cs
+++ b/src/DistributionCenter.Infraestructure/Validators/Core/Concretes/Products/UpdateProductValidator.cs
@@ -18,5 +18,10 @@ public class UpdateProductValidator : BaseFluentValidator<UpdateProductDto>
         _ = RuleFor(static product => product.Description)!
             .WhenNotNull()
             .SizeRange(3, 128, "The description has a limit of 128 characters");
+
+        _ = RuleFor(static product => product.Weight)
+            .WhenNotNull()
+            .NonNegatives("The weight can't be a negative number")
+            .NumberRange(0, 1000000, "The weight has a limit of 1000000 gr/ml");
     }
 }

--- a/src/DistributionCenter.Infraestructure/Validators/Core/Concretes/Transports/CreateTransportValidator.cs
+++ b/src/DistributionCenter.Infraestructure/Validators/Core/Concretes/Transports/CreateTransportValidator.cs
@@ -9,14 +9,14 @@ public class CreateTransportValidator : BaseFluentValidator<CreateTransportDto>
     public CreateTransportValidator()
     {
         _ = RuleFor(static transport => transport.Name)!
-            .WhenNotNull()
+            .NotNullNotEmpty("Name is required")
             .SizeRange(1, 20, "Name must be between 1 and 20 characters")
             .RegexValidator(
                 @"^[a-zA-Z0-9\s]+$",
                 "Name must contain letters, numbers and spaces");
 
         _ = RuleFor(static transport => transport.Plate)!
-            .WhenNotNull()
+            .NotNullNotEmpty("Plate is required")
             .SizeRange(4, 7, "Plate must be between 4 and 7 characters")
             .RegexValidator(
                 @"^[0-9]{1,4}[A-Z]{3}$",

--- a/test/DistributionCenter.Infraestructure.Tests/DTOs/Concretes/Products/UpdateProductDtoTests.cs
+++ b/test/DistributionCenter.Infraestructure.Tests/DTOs/Concretes/Products/UpdateProductDtoTests.cs
@@ -22,7 +22,8 @@ public class UpdateProductDtoTests
             new()
             {
                 Name = "Pepsi Zero Personal",
-                Description = "Lorem ipsum dolor bae"
+                Description = "Lorem ipsum dolor bae",
+                Weight = expectedWeight,
             };
 
         // Execute actual operation
@@ -49,7 +50,8 @@ public class UpdateProductDtoTests
         UpdateProductDto dto = new()
         {
             Name = null,
-            Description = null
+            Description = null,
+            Weight = null
         };
 
         // Execute actual operation
@@ -70,14 +72,16 @@ public class UpdateProductDtoTests
             new()
             {
                 Name = "Sh",
-                Description = "or"
+                Description = "or",
+                Weight = null
             };
 
         UpdateProductDto validDto =
             new()
             {
                 Name = "Valid Name 2",
-                Description = "Valid Description"
+                Description = "Valid Description",
+                Weight = null
             };
 
         // Execute actual operation

--- a/test/DistributionCenter.Infraestructure.Tests/Validators/Products/UpdateProductValidatorTests.cs
+++ b/test/DistributionCenter.Infraestructure.Tests/Validators/Products/UpdateProductValidatorTests.cs
@@ -17,12 +17,14 @@ public class UpdateProductValidatorTests
         UpdateProductDto invalidDto = new()
         {
             Name = invalidName,
-            Description = "Some long and valid description"
+            Description = "Some long and valid description",
+            Weight = 1000
         };
         UpdateProductDto validDto = new()
         {
             Name = validName,
-            Description = "Some long and valid description"
+            Description = "Some long and valid description",
+            Weight = 1000
         };
 
         // Verify actual result
@@ -43,12 +45,14 @@ public class UpdateProductValidatorTests
         UpdateProductDto invalidDto = new()
         {
             Name = invalidName,
-            Description = "Some long and valid description"
+            Description = "Some long and valid description",
+            Weight = 1000
         };
         UpdateProductDto validDto = new()
         {
             Name = validName,
-            Description = "Some long and valid description"
+            Description = "Some long and valid description",
+            Weight = 1000
         };
 
         // Verify actual result
@@ -68,12 +72,14 @@ public class UpdateProductValidatorTests
         UpdateProductDto invalidDto = new()
         {
             Name = "Pepsi Zero 2Lts",
-            Description = invalidDescription
+            Description = invalidDescription,
+            Weight = 1000
         };
         UpdateProductDto validDto = new()
         {
             Name = "Pepsi Zero 2Lts",
-            Description = validDescription
+            Description = validDescription,
+            Weight = 1000
         };
 
         // Verify actual result
@@ -96,12 +102,14 @@ public class UpdateProductValidatorTests
         UpdateProductDto invalidDto = new()
         {
             Name = "Pepsi Zero 2Lts",
-            Description = invalidDescription
+            Description = invalidDescription,
+            Weight = 1000
         };
         UpdateProductDto validDto = new()
         {
             Name = "Pepsi Zero 2Lts",
-            Description = validDescription
+            Description = validDescription,
+            Weight = 1000
         };
 
         // Verify actual result


### PR DESCRIPTION
# Pull Request

**User Story Link:** https://app.clickup.com/t/8689x4wdn

This pull request fixes a bug related to the visibility of the Weight field in Swagger when trying to create or update a product. The error occurred because the Weight attribute was not visible in the Swagger documentation, which generated errors when sending requests to store products, since the Weight field is required but was not being sent correctly. To solve this problem, the corresponding DTOs and Swagger configuration have been updated.

<!--
  Thanks for contributing to this API project!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality
      to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
